### PR TITLE
Matched click classifier bug fixes and TDDisplayFX real time changes

### DIFF
--- a/src/dataPlotsFX/scroller/TDAcousticScroller.java
+++ b/src/dataPlotsFX/scroller/TDAcousticScroller.java
@@ -184,15 +184,21 @@ public class TDAcousticScroller extends AcousticScrollerFX implements PamSetting
 		
 		//add a listener so the visible amount changes of the spinner changes value. 
 		spinner.valueProperty().addListener((obsVal, oldVal, newVal)->{
-			if (spinnerCall) return ; //prevent overflow. 
-			if (newVal<=this.getRangeMillis()) {
-//					Debug.out.println("TDAcousticScroller: TimeRangeSpinner: " + newVal);
-				Platform.runLater(()->{ //why? But seems necessary
-					super.setVisibleMillis(newVal);
-				}); 
-			}
-			else spinner.getValueFactory().decrement(1); //need to use decrement here instead of set time because otherwise arrow buttons
-			//don't work. 
+			if (spinnerCall) return ; //prevent overflow
+			
+			/**
+			 * There are two slightly different modes here- in viewer mode we want the spinner to set
+			 * only the visible range. However in real time mode we want it to set the visible time and
+			 * the data keep time. 
+			 */
+				if (newVal<=this.getRangeMillis() || !isViewer) {
+	//					Debug.out.println("TDAcousticScroller: TimeRangeSpinner: " + newVal);
+					Platform.runLater(()->{ //why? But seems necessary
+						super.setVisibleMillis(newVal);
+						super.setRangeMillis(0, newVal, false); 
+					}); 
+				}
+				else spinner.getValueFactory().decrement(1); //need to use decrement here instead of set time because otherwise arrow buttons
 		});
 	}
 

--- a/src/matchedTemplateClassifer/MTClassifier.java
+++ b/src/matchedTemplateClassifer/MTClassifier.java
@@ -12,8 +12,6 @@ import com.jmatio.types.MLStructure;
 
 import Filters.SmoothingFilter;
 import Localiser.DelayMeasurementParams;
-import Localiser.algorithms.Correlations;
-import Localiser.algorithms.TimeDelayData;
 import PamModel.parametermanager.ManagedParameters;
 import PamModel.parametermanager.PamParameterSet;
 import PamModel.parametermanager.PrivatePamParameterData;
@@ -96,15 +94,15 @@ public class MTClassifier implements Serializable, Cloneable, ManagedParameters 
 	 */
 	transient private WavInterpolator wavInterpolator = new WavInterpolator(); 
 	
-	/**
-	 * The delay measurment parameters. 
-	 */
-	private transient DelayMeasurementParams delayMeasurementParams = defualtDelayParams(); 
-
-	/**
-	 * Runs the cross correlation algorithm. 
-	 */
-	private transient Correlations correlations = new Correlations(); 
+//	/**
+//	 * The delay measurment parameters. 
+//	 */
+//	private transient DelayMeasurementParams delayMeasurementParams = defualtDelayParams(); 
+//
+//	/**
+//	 * Runs the cross correlation algorithm. 
+//	 */
+//	private transient Correlations correlations = new Correlations(); 
 	
 	/**
 	 * Default MT classifier 

--- a/src/matchedTemplateClassifer/MTClassifier.java
+++ b/src/matchedTemplateClassifer/MTClassifier.java
@@ -91,7 +91,7 @@ public class MTClassifier implements Serializable, Cloneable, ManagedParameters 
 	/**
 	 * Decimates waveforms. 
 	 */
-	private WavInterpolator wavInterpolator = new WavInterpolator(); 
+	transient private WavInterpolator wavInterpolator = new WavInterpolator(); 
 
 	
 	/**

--- a/src/matchedTemplateClassifer/MTClassifier.java
+++ b/src/matchedTemplateClassifer/MTClassifier.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.lang.reflect.Field;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.jamdev.jpamutils.wavFiles.WavInterpolator;
 
 import com.jmatio.types.MLArray;
 import com.jmatio.types.MLDouble;
@@ -86,6 +87,12 @@ public class MTClassifier implements Serializable, Cloneable, ManagedParameters 
 
 
 	public final static int TEST_FFT_LENGTH=300; 
+	
+	/**
+	 * Decimates waveforms. 
+	 */
+	private WavInterpolator wavInterpolator = new WavInterpolator(); 
+
 	
 	/**
 	 * Default MT classifier 
@@ -444,9 +451,25 @@ public class MTClassifier implements Serializable, Cloneable, ManagedParameters 
 	 */
 	private double[] interpWaveform(MatchTemplate waveformMatch, double sR) {
 		//System.out.println("Interp waveform: " + " old: " + waveformMatch.sR + " new: " +  sR);
+		
+		if ( waveformMatch.sR>sR) {
+			//up sample
 			double[] interpWaveformMatch=reSampleWaveform(waveformMatch.waveform, waveformMatch.sR, sR);
-			//System.out.println("RESULT: old len: " + waveformMatch.waveform.length + "  new len: " +interpWaveformMatch.length);
 			return interpWaveformMatch; 
+		}
+		else if (waveformMatch.sR<sR){
+//			//TODO - make a better decimator?
+//			double[] interpWaveformMatch=reSampleWaveform(waveformMatch.waveform, waveformMatch.sR, sR);
+//			return interpWaveformMatch; 
+			if (wavInterpolator == null) wavInterpolator = new WavInterpolator(); 
+			return wavInterpolator.decimate(waveformMatch.waveform, waveformMatch.sR, (float) sR); 
+		}
+		else {
+			//nothing needed/ 
+			return waveformMatch.waveform;
+		}
+		
+			
 	}
 	
 	

--- a/src/matchedTemplateClassifer/MTClassifierTest.java
+++ b/src/matchedTemplateClassifer/MTClassifierTest.java
@@ -72,19 +72,32 @@ public class MTClassifierTest {
 		return struct; 
 	}
 	
+	/**
+	 * Test the correlation of several templates
+	 * @param testWaveform - the waveform to correlate against. 
+	 * @param sR - the sample rate of the waveform. 
+	 * @param templates - the match templates to test. 
+	 */
+	private static void testCorrelation(double[] testWaveform, float sR, ArrayList<MatchTemplate> templates) {
+		testCorrelation(testWaveform,  sR,  templates, MatchedTemplateParams.NORMALIZATION_RMS); 
+	}
+
+	
+	
 	
 	/**
 	 * Test the correlation of several templates
-	 * @param testWaveform
-	 * @param sR
-	 * @param templates
-	 * @return
+	 * @param testWaveform - the waveform to correlate against. 
+	 * @param sR - the sample rate of the waveform. 
+	 * @param templates - the match templates to test. 
+	 * @param normalisation - the normalisation type to use e.g.  MatchedTemplateParams.NORMALIZATION_RMS
 	 */
-	private static void testCorrelation(double[] testWaveform, float sR, ArrayList<MatchTemplate> templates) {
+	private static void testCorrelation(double[] testWaveform, float sR, ArrayList<MatchTemplate> templates, int normalisation) {
 
 		//create the classifier object 
 		for (int i=0; i<templates.size(); i++){
 			MTClassifier mtclassifier = new MTClassifier(); 
+			mtclassifier.normalisation = normalisation; 
 			
 			//System.out.println("Template " + i + " " + templates.get(i));
 			//add templates if inpout 
@@ -97,7 +110,13 @@ public class MTClassifierTest {
 
 			//System.out.println("Waveform len: " +testWaveform.length + " min: " + PamArrayUtils.min(testWaveform) +  " max: " + PamArrayUtils.max(testWaveform)); 
 
+		
 			testWaveform=PamArrayUtils.divide(testWaveform, PamUtils.PamArrayUtils.max(testWaveform));
+			
+			testWaveform = MTClassifier.normaliseWaveform(testWaveform, MatchedTemplateParams.NORMALIZATION_RMS);
+			
+			System.out.println("Waveform max: " + PamArrayUtils.max(testWaveform) + " len: " + testWaveform.length); 
+
 			
 			//calculate the click FFT. 
 			fft = new FastFFT(); 
@@ -303,7 +322,10 @@ public class MTClassifierTest {
 		
 	}
 	
-	public static void testMatchCorr() {
+	/**
+	 * Test how the length of the waveform affects the match correlation values
+	 */
+	public static void testMatchCorrLen() {
 		
 		String testClicksPath = "/Users/au671271/MATLAB-Drive/MATLAB/PAMGUARD/matchedclickclassifer/DS2clks_test.mat";
 		String templteFilePath= "/Users/au671271/MATLAB-Drive/MATLAB/PAMGUARD/matchedclickclassifer/DS2templates_test.mat";
@@ -330,6 +352,20 @@ public class MTClassifierTest {
 				 restrictedBins, WindowFunction.hann(restrictedBins)); 
 		
 		testCorrelation(waveformLen,  sR, templates); 
+		
+	}
+	
+	/**
+	 * Test the match corr algorithm by cross correlating a waveform with itself. 
+	 */
+	public static void testMatchCorr() {
+		
+		String templteFilePath= "/Users/au671271/MATLAB-Drive/MATLAB/PAMGUARD/matchedclickclassifer/DS2templates_test.mat";
+		//float sR = 288000; //sample rate in samples per second. 
+
+		ArrayList<MatchTemplate> templates = importTemplates(templteFilePath); 
+		
+		testCorrelation(templates.get(0).waveform,  templates.get(0).sR, templates); 
 		
 	}
 	

--- a/src/matchedTemplateClassifer/MTClassifierTest.java
+++ b/src/matchedTemplateClassifer/MTClassifierTest.java
@@ -115,7 +115,7 @@ public class MTClassifierTest {
 			
 			testWaveform = MTClassifier.normaliseWaveform(testWaveform, MatchedTemplateParams.NORMALIZATION_RMS);
 			
-			System.out.println("Waveform max: " + PamArrayUtils.max(testWaveform) + " len: " + testWaveform.length); 
+			//System.out.println("Waveform max: " + PamArrayUtils.max(testWaveform) + " len: " + testWaveform.length); 
 
 			
 			//calculate the click FFT. 
@@ -196,7 +196,7 @@ public class MTClassifierTest {
 				MLDouble clickUID=(MLDouble) mlArrayRetrived.getField("UID", i);
 
 				
-				clicks.add(new MatchTemplate(Integer.toString((int) clickUID.get(0).doubleValue()), waveform, 288000)); 
+				clicks.add(new MatchTemplate(Long.toString(clickUID.get(0).longValue()), waveform, 288000)); 
 			}
 			return clicks; 
 		} 
@@ -327,14 +327,14 @@ public class MTClassifierTest {
 	 */
 	public static void testMatchCorrLen() {
 		
-		String testClicksPath = "/Users/au671271/MATLAB-Drive/MATLAB/PAMGUARD/matchedclickclassifer/DS2clks_test.mat";
-		String templteFilePath= "/Users/au671271/MATLAB-Drive/MATLAB/PAMGUARD/matchedclickclassifer/DS2templates_test.mat";
+		String testClicksPath = "/Users/au671271/MATLAB-Drive/MATLAB/PAMGUARD/matchedclickclassifer/DS3clks_test.mat";
+		String templteFilePath= "/Users/au671271/MATLAB-Drive/MATLAB/PAMGUARD/matchedclickclassifer/DS3templates_test.mat";
 		
 		float sR = 288000; //sample rate in samples per second. 
 		ArrayList<MatchTemplate> clicks = importClicks(testClicksPath, sR); 
 		ArrayList<MatchTemplate> templates = importTemplates(templteFilePath); 
 		
-		int index = 0; 
+		int index = 24; 
 		//values in MATLAB are9.73577287114938	8.82782814105430	3.51936216182390
 		System.out.println("Number of clicks: " + clicks.size() + " UID " + clicks.get(index).name); 
 		
@@ -343,7 +343,7 @@ public class MTClassifierTest {
 		
 		System.out.println("------Restricted Length--------"); 
 
-		int restrictedBins= 1024; 
+		int restrictedBins= 2048; 
 		
 		ClickLength clickLength = new ClickLength(); 
 		int[][] lengthPoints =  clickLength.createLengthData(clicks.get(index), sR, 5.5, 3, false, null); 
@@ -371,7 +371,7 @@ public class MTClassifierTest {
 	
 	
 	public static void main(String args[]) {
-		testMatchCorr(); 
+		testMatchCorrLen(); 
 	}
 	
 

--- a/src/matchedTemplateClassifer/MTClassifierTest.java
+++ b/src/matchedTemplateClassifer/MTClassifierTest.java
@@ -134,14 +134,25 @@ public class MTClassifierTest {
 			MatchedTemplateResult matchResult = mtclassifier.calcCorrelationMatch(matchClick, sR);
 						
 			
-			System.out.println(String.format("The match correlation for %d is %.5f", i, matchResult.matchCorr)); 
+			System.out.println(String.format("The match correlation for %d is %.5f", i, matchResult.matchCorr));
+//			
+//			 printFFt(matchClick);
+//			 
+//			 System.out.println("-----------------------");
+//			
+//			 ComplexArray matchTemplate = mtclassifier.getWaveformMatchFFT(sR, matchClick.length()*2); 
+//
+//			 printFFt(matchTemplate);
+
+
 		}
 
 	}
 	
 	public static void printFFt(ComplexArray complexArray) {
 		for (int i=0; i<complexArray.length(); i++ ) {
-			System.out.println(complexArray.get(i).toString(6));
+			//System.out.println(complexArray.get(i).toString(6));
+			System.out.println(complexArray.get(i).real + "," + complexArray.get(i).imag);
 		}
 	}
 	

--- a/src/matchedTemplateClassifer/layoutFX/MTSettingsPane.java
+++ b/src/matchedTemplateClassifer/layoutFX/MTSettingsPane.java
@@ -257,7 +257,7 @@ public class MTSettingsPane extends SettingsPane<MatchedTemplateParams> {
 
 		//click normalisation 
 		normBox = new ComboBox<String>();
-		normBox.getItems().addAll("peak to peak", "RMS", "none"); 
+		normBox.getItems().addAll("peak to peak", "norm", "none"); 
 
 		PamHBox clickNormPane= new PamHBox(); 
 		clickNormPane.setSpacing(5);

--- a/src/matchedTemplateClassifer/offline/MTOfflineProcess.java
+++ b/src/matchedTemplateClassifer/offline/MTOfflineProcess.java
@@ -65,6 +65,8 @@ public class MTOfflineProcess {
 		//System.out.println("Click train offline data block " + clickTrainControl.getParentDataBlock());
 		mtOfflineGroup.setPrimaryDataBlock(mtContorl.getParentDataBlock());
 		mtOfflineTask.setParentDataBlock(mtContorl.getParentDataBlock());
+		//need this to make sure annotations trigger saving. 
+        mtOfflineTask.addAffectedDataBlock(mtContorl.getParentDataBlock());
 		
 		//if null open the dialog- also create a new offlineTask group if the datablock has changed. 
 		if (mtOfflineDialog == null) {

--- a/src/rawDeepLearningClassifier/dlClassification/genericModel/GenericModelTest.java
+++ b/src/rawDeepLearningClassifier/dlClassification/genericModel/GenericModelTest.java
@@ -75,7 +75,6 @@ public class GenericModelTest {
 				//long time1 = System.currentTimeMillis();
 				data = new float[][][] {DLUtils.toFloatArray(((FreqTransform) transform).getSpecTransfrom().getTransformedData())}; 
 				
-				
 				//data = new float[][][] { DLUtils.makeDummySpectrogram(40, 40)}; 
 				
 				//System.out.println("data len: " + data.length + " " + data[0].length + " " +  data[0][0].length); 


### PR DESCRIPTION
There were issues with the matched click classifier 
1) The correlation value was not 1 with two identical waveforms
2) A flipped array had been used instead of the complex conjugate which sort of works but is more processor intensive and less correct than the complex conjugate. 
3) The decimation and up sampling was a little crude and has been updated to use a WavInterpolator class. 
4) The offline processing was not working for "All Data" option in view mode. Needed to use _addAffectedDataBlock_ function. 

In real time the TDdisplayFX had a five min max - this has been changed to allow unlimited times with the risk a user may crash the display if too may data units are shown. 