### PR TITLE
Bug fix for matched click classifier

### DIFF
--- a/src/clickDetector/ClickAlarmManager.java
+++ b/src/clickDetector/ClickAlarmManager.java
@@ -108,6 +108,9 @@ public class ClickAlarmManager extends PamProcess {
 //        System.out.println("ClickAlarm hashcode, time = " + System.identityHashCode(arg) + "," + cd.getTimeMilliseconds() + "," + cd.getClickType() );
         if (cd.getClickType()!=0) {
             ClickTypeCommonParams commonParams = clickControl.getClickIdentifier().getCommonParams(cd.getClickType());
+            
+            if (commonParams==null) return;
+            	
             Boolean soundAlarm = commonParams.getAlarmEnabled();
 
             if (soundAlarm != null && soundAlarm) {

--- a/src/clickDetector/ClickClassifiers/basic/BasicClickIdentifier.java
+++ b/src/clickDetector/ClickClassifiers/basic/BasicClickIdentifier.java
@@ -401,6 +401,7 @@ public class BasicClickIdentifier implements ClickIdentifier, PamSettings {
      */
     public ClickTypeCommonParams getCommonParams(int code) {
         int codeIdx = codeToListIndex(code);
+        if (codeIdx>=idParameters.clickTypeParams.size()) return null; 
         return idParameters.clickTypeParams.get(codeIdx);
     }
 

--- a/src/matchedTemplateClassifer/ImportTemplateCSV.java
+++ b/src/matchedTemplateClassifer/ImportTemplateCSV.java
@@ -53,7 +53,7 @@ public class ImportTemplateCSV implements TemplateImport {
 		//now create waveform
 //		System.out.println("Create a waveform with " + waveform.length + " samples with a sample rate of "
 //				+ sR + " Hz");
-		MatchTemplate matchedTemplate = new MatchTemplate("Imported Waveform", waveform, sR);
+		MatchTemplate matchedTemplate = new MatchTemplate(filePath.getName(), waveform, sR);
 		//TODO		
 		return matchedTemplate; 
 	}

--- a/src/matchedTemplateClassifer/ImportTemplateMAT.java
+++ b/src/matchedTemplateClassifer/ImportTemplateMAT.java
@@ -60,7 +60,7 @@ public class ImportTemplateMAT implements TemplateImport {
 			//now create waveform
 //			System.out.println("Create a waveform with " + waveform.length + " samples with a sample rate of "
 //					+ sR + " Hz");
-			MatchTemplate matchedTemplate = new MatchTemplate("Imported Waveform", waveform, sR);
+			MatchTemplate matchedTemplate = new MatchTemplate(filePath.getName(), waveform, sR);
 			return matchedTemplate; 
 			
 		} catch (FileNotFoundException e) {


### PR DESCRIPTION
Some of the alarm stuff in the click detector was throwing an exception because the matched click classifier adds a click ID that is not in the click ID module's list...now fixed and test with porpoises.