### PR TITLE
Add noise exports and numerous bug fixes

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -6,7 +6,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/ojdk-21.0.1">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.launching.macosx.MacOSXType/JRE [21.0.6]">
 		<attributes>
 			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>

--- a/src/dataPlotsFX/TDControl.java
+++ b/src/dataPlotsFX/TDControl.java
@@ -11,6 +11,8 @@ import PamguardMVC.PamDataBlock;
 import PamguardMVC.PamObserver;
 import dataPlots.TDParameters;
 import dataPlotsFX.data.TDDataInfoFX;
+import dataPlotsFX.data.TDDataProviderFX;
+import dataPlotsFX.data.TDDataProviderRegisterFX;
 import dataPlotsFX.layout.TDDisplayFX;
 import dataPlotsFX.layout.TDGraphFX;
 import detectiongrouplocaliser.DetectionGroupSummary;
@@ -229,6 +231,19 @@ public abstract class TDControl implements PamSettings {
 	 */
 	public void newSelectedDetectionGroup(DetectionGroupSummary detectionGroup, TDGraphFX tdGraph) {
 		
+	}
+	
+	/**
+	 * Update the provider register. This removes any data block which no longer exist in the data model. 
+	 */
+	public void updateProviderRegister() {
+		ArrayList<TDDataProviderFX> dataInfos=TDDataProviderRegisterFX.getInstance().getDataInfos();
+		for (int i=0; i<dataInfos.size() ;i++){
+			if (!PamController.getInstance().getDataBlocks().contains(dataInfos.get(i).getDataBlock())){
+				//no datablock in model. must unregister!
+				TDDataProviderRegisterFX.getInstance().unRegisterDataInfo(dataInfos.get(i));
+			}
+		}
 	}
 
 

--- a/src/dataPlotsFX/TDControlAWT.java
+++ b/src/dataPlotsFX/TDControlAWT.java
@@ -80,6 +80,7 @@ public class TDControlAWT  extends TDControl implements UserDisplayComponent {
 		 * button and other controls until this thread has completed.
 		 */
 		PAMStartupEnabler.addDisableCount();
+		
 		Platform.runLater(new Runnable() {
 			@Override
 			public void run() {

--- a/src/dataPlotsFX/TDControlFX.java
+++ b/src/dataPlotsFX/TDControlFX.java
@@ -355,18 +355,6 @@ public class TDControlFX extends TDControl implements UserDisplayNodeFX {
 		return false;
 	}
 
-	/**
-	 * Update the provider register. This removes any data block which no longer exist in the data model. 
-	 */
-	public void updateProviderRegister() {
-		ArrayList<TDDataProviderFX> dataInfos=TDDataProviderRegisterFX.getInstance().getDataInfos();
-		for (int i=0; i<dataInfos.size() ;i++){
-			if (!PamController.getInstance().getDataBlocks().contains(dataInfos.get(i).getDataBlock())){
-				//no datablock in model. must unregister!
-				TDDataProviderRegisterFX.getInstance().unRegisterDataInfo(dataInfos.get(i));
-			}
-		}
-	}
 	
 	/**
 	 * Called just before settings are saved. Will have to go 

--- a/src/dataPlotsFX/TDDisplayController.java
+++ b/src/dataPlotsFX/TDDisplayController.java
@@ -94,7 +94,7 @@ public class TDDisplayController extends UserDisplayControlFX {
 	@Override
 	public void notifyModelChanged(int type){
 //		System.out.println("---------------------------------" ); 
-//		System.out.println("TDisplayController: flag: " + type); 
+		System.out.println("TDisplayController: flag: " + type); 
 		super.notifyModelChanged(type);
 		switch (type){
 		case PamControllerInterface.INITIALIZATION_COMPLETE:

--- a/src/dataPlotsFX/data/generic/GenericLinePlotInfo.java
+++ b/src/dataPlotsFX/data/generic/GenericLinePlotInfo.java
@@ -84,7 +84,8 @@ public abstract class GenericLinePlotInfo extends TDDataInfoFX {
 	 */
 	public Polygon drawPredicition(int plotNumber, PamDataUnit pamDataUnit, GraphicsContext g, double scrollStart,
 			TDProjectorFX tdProjector, int type) {
-		//		System.out.println("A Plot line: "  + PamCalendar.formatDateTime(pamDataUnit.getTimeMilliseconds()));
+		
+		//System.out.println("A Plot line: "  + PamCalendar.formatDateTime(pamDataUnit.getTimeMilliseconds()));
 
 
 		double mintC= -1000.;
@@ -129,8 +130,9 @@ public abstract class GenericLinePlotInfo extends TDDataInfoFX {
 		Color color;
 		double dataBin; //the time between the data points in millis
 
-		//		System.out.println("A Plot line 2: "  + PamCalendar.formatDateTime(pamDataUnit.getTimeMilliseconds()) + " detData " + detData.length);
+		//System.out.println("A Plot line 2: "  + PamCalendar.formatDateTime(pamDataUnit.getTimeMilliseconds()) + " detData " + detData.length + " " +  detData[0].length);
 
+		//iterate through each line from det data
 		for (int i=0; i<detData.length; i++) {
 
 			if (getColor(i).enabled) {
@@ -139,6 +141,7 @@ public abstract class GenericLinePlotInfo extends TDDataInfoFX {
 				g.setStroke(color);
 				g.setFill(color); 
 
+				//iterate through each data point in the line
 				for (int j=0; j<detData[i].length; j++) {
 					
 					if (lastUnits[chan][i]!=null && lastUnits[chan][i].getTimeMillis()>pamDataUnit.getTimeMilliseconds() ) {
@@ -165,8 +168,7 @@ public abstract class GenericLinePlotInfo extends TDDataInfoFX {
 						
 						
 						g.fillOval(tC-OVAL_RADIUS/2, dataPixel-OVAL_RADIUS/2, OVAL_RADIUS,OVAL_RADIUS);
-						//						System.out.println("Fill oval:");
-						return null; 
+
 					}
 					else {
 						if (tC>lastUnits[chan][i].getX() && (!this.getTDGraph().isWrap() ||

--- a/src/dataPlotsFX/layout/TDDisplayFX.java
+++ b/src/dataPlotsFX/layout/TDDisplayFX.java
@@ -700,15 +700,20 @@ public class TDDisplayFX extends PamBorderPane {
 		//		System.out.println("timeScrollerFX.getMaximumMillis() "+timeScrollerFX.getMaximumMillis()+" timeScrollerFX.getMinimumMillis() "+
 		//						timeScrollerFX.getMinimumMillis()+" "+timeScrollerFX.getObservers().size()+ " "+timeScrollerFX.getNumUsedDataBlocks()+" vis amount "+timeScrollerFX.getVisibleAmount()
 		//						+" rangeMillis(): "+timeScrollerFX.getRangeMillis());
-		//		System.out.println(String.format("ScrollerFX set start %s, End %s, pos %s pc time %s", PamCalendar.formatTime(scrollStart),
-		//		PamCalendar.formatTime(scrollEnd),PamCalendar.formatTime(scrollPos), PamCalendar.formatTime(System.currentTimeMillis())));
+//				System.out.println(String.format("ScrollerFX set start %s, End %s, pos %s pc time %s", PamCalendar.formatTime(scrollStart),
+//				PamCalendar.formatTime(scrollEnd),PamCalendar.formatTime(scrollPos, true), PamCalendar.formatTime(System.currentTimeMillis(), true)));
 		getTimeScroller().setRangeMillis(scrollStart, scrollEnd, true);
 		getTimeScroller().setVisibleMillis(tdParametersFX.visibleTimeRange);
 		getTimeScroller().setValueMillis(scrollPos);
 
 		setTimeStamp();
 
+//		long time0 = System.currentTimeMillis();
 		repaintAll(STANDARD_REFRESH_MILLIS);
+//		long time1 = System.currentTimeMillis();
+		
+//		System.out.println("Time repaint all: " + (time1-time0));
+
 
 	}
 
@@ -737,13 +742,13 @@ public class TDDisplayFX extends PamBorderPane {
 		}
 	}
 
-	/**
-	 * Cycles through all the time data graphs and updates the plot display. 
-	 * @param flag - a canvas repaint flag e.g. TDPlotPane.FRONT_CANAVAS.  
-	 */
-	public void repaintAll(int flag){
-		repaintAll(0, flag);
-	}
+//	/**
+//	 * Cycles through all the time data graphs and updates the plot display. 
+//	 * @param flag - a canvas repaint flag e.g. TDPlotPane.FRONT_CANAVAS.  
+//	 */
+//	public void repaintAll(int flag){
+//		repaintAll(0, flag);
+//	}
 
 	/**
 	 * Cycles through all the time data graphs and updates the plot display. 
@@ -769,7 +774,7 @@ public class TDDisplayFX extends PamBorderPane {
 		timeScrollerFX.scrollerChangingProperty().addListener((obsVal, oldVal, newVal)->{
 			//only repaint if the scroller has stopped moving. 
 			if (!newVal && (newVal!=oldVal)){
-				this.repaintAll(10);
+				this.repaintAll(10L);
 				oldVal=newVal; 
 			}
 		});
@@ -896,6 +901,7 @@ public class TDDisplayFX extends PamBorderPane {
 				}
 				setTimeStamp();
 				repaintAll(STANDARD_REFRESH_MILLIS);
+
 			});
 		}
 
@@ -915,7 +921,6 @@ public class TDDisplayFX extends PamBorderPane {
 					aGraph.timeScrollRangeChanged(pamScroller.getMinimumMillis(), pamScroller.getMaximumMillis());
 				}
 				setTimeStamp();
-				System.out.println("Scroll range changed"); 
 				repaintAll(0);
 			});
 		}
@@ -1189,6 +1194,8 @@ public class TDDisplayFX extends PamBorderPane {
 			//			this.repaintAll();
 			break; 
 		case PamController.CHANGED_PROCESS_SETTINGS:
+			//might need to update the register to remove any data info
+			this.getTDControl().updateProviderRegister();
 			break;
 		}
 

--- a/src/dataPlotsFX/scrollingPlot2D/Scrolling2DPlotInfo.java
+++ b/src/dataPlotsFX/scrollingPlot2D/Scrolling2DPlotInfo.java
@@ -236,8 +236,14 @@ abstract public class Scrolling2DPlotInfo extends TDDataInfoFX implements Plot2D
 		 */
 		try{
 			if (chan >= 0 && scrolling2DPlotData[chan] != null) {
+				long time0 = System.currentTimeMillis();
+
 				scrolling2DPlotData[chan].drawSpectrogram(g, tdProjector.getWindowRect(), 
 						tdProjector.getOrientation(), tdProjector.getTimeAxis(), scrollStart, tdProjector.isWrap());
+				
+				long time1 = System.currentTimeMillis();
+				//System.out.println("chan: "+plotNumber + " draw: " + (time1-time0) + " " + scrollStart); 
+
 			}
 		}
 		catch (Exception e){
@@ -401,15 +407,13 @@ abstract public class Scrolling2DPlotInfo extends TDDataInfoFX implements Plot2D
 
 				new2DData((DataUnit2D) dataUnit); //do not put in FX thread!
 				
-
-				
-				
 				Platform.runLater(()->{
 					//only repaint the base canvas. Otherwise overlaid detections will repaint and this can take a 
 					//a very long time. 
 					if (isViewer)
 						getTDGraph().repaint(TDDisplayFX.STANDARD_REFRESH_MILLIS, TDPlotPane.BASE_CANVAS);
 					else {
+//						System.out.println("Repaint!: spec: ");
 						//01/11/2019
 						// change back to repaint everything - if we only repaint the base canvas, the spectrogram will scroll continuously but
 						// overlay data will only get updated periodically and get out of sync with the spectrogram image
@@ -485,19 +489,6 @@ abstract public class Scrolling2DPlotInfo extends TDDataInfoFX implements Plot2D
 	 * @param dataUnit2D
 	 */
 	public void new2DData(DataUnit2D dataUnit2D) {
-		
-		//TODO - added this here because sometimes a data order returns units that are from the 
-		//the wrong time. Not sure why this is but likely to do with queue issues perhaps. This 
-		//temporary fix will help but will not work when we move the spectrogram to loading sections
-		//of data outwith the visible display
-		if (dataUnit2D.getTimeMilliseconds() < (getVisibleStart() -getSmooshMillis()) ||
-				dataUnit2D.getTimeMilliseconds() > getVisibleEnd()	) {
-			//System.out.println("data unit not in range: " + PamCalendar.formatDateTime2(dataUnit2D.getTimeMilliseconds())); 
-
-			return;
-		}
-		
-
 
 		int chan = PamUtils.getSingleChannel(dataUnit2D.getSequenceBitmap());
 
@@ -611,7 +602,7 @@ abstract public class Scrolling2DPlotInfo extends TDDataInfoFX implements Plot2D
 		long dataStart = getVisibleStart()-getSmooshMillis();
 		long dataEnd = getVisibleEnd();
 		
-		System.out.println("Order offline data from: " + PamCalendar.formatDateTime2(dataStart) + "to : " + PamCalendar.formatDateTime2(dataEnd) + "  " + getSmooshMillis());
+		//System.out.println("Order offline data from: " + PamCalendar.formatDateTime2(dataStart) + "to : " + PamCalendar.formatDateTime2(dataEnd) + "  " + getSmooshMillis());
 
 		if (lastReqStart == dataStart && lastReqEnd == dataEnd) {
 			return true;

--- a/src/export/MLExport/MLCPODExport.java
+++ b/src/export/MLExport/MLCPODExport.java
@@ -2,6 +2,7 @@ package export.MLExport;
 
 import org.jamdev.jdl4pam.utils.DLMatFile;
 
+import PamguardMVC.PamDataBlock;
 import PamguardMVC.PamDataUnit;
 import cpod.CPODClick;
 import cpod.CPODClickTrainDataUnit;
@@ -106,6 +107,12 @@ public class MLCPODExport extends MLDataUnitExport<PamDataUnit<?, ?>>{
 	@Override
 	public String getName() {
 		return "cpod";
+	}
+
+	@Override
+	protected Struct detectionHeader(PamDataBlock pamDataBlock) {
+		// TODO Auto-generated method stub
+		return null;
 	}
 
 }

--- a/src/export/MLExport/MLDataUnitExport.java
+++ b/src/export/MLExport/MLDataUnitExport.java
@@ -3,6 +3,7 @@ package export.MLExport;
 import org.jamdev.jdl4pam.utils.DLMatFile;
 
 import PamUtils.PamCalendar;
+import PamguardMVC.PamDataBlock;
 import PamguardMVC.PamDataUnit;
 import pamMaths.PamVector;
 import us.hebi.matlab.mat.format.Mat5;
@@ -171,5 +172,12 @@ public abstract class MLDataUnitExport<T extends PamDataUnit<?, ?>> {
 
 		return new double[] {bearing, pitch};
 	}
+
+	/**
+	 * Get the detection header for the specific detection type.
+	 * @param pamDataBlock 
+	 * @return the detection header structure. 
+	 */
+	protected abstract Struct detectionHeader(PamDataBlock pamDataBlock);
 	
 }

--- a/src/export/MLExport/MLDetectionsManager.java
+++ b/src/export/MLExport/MLDetectionsManager.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.zip.Deflater;
 
 import PamUtils.PamArrayUtils;
+import PamguardMVC.PamDataBlock;
 import PamguardMVC.PamDataUnit;
 import export.PamDataUnitExporter;
 import javafx.scene.layout.Pane;
@@ -63,6 +64,7 @@ public class MLDetectionsManager implements PamDataUnitExporter {
 		mlDataUnitsExport.add(new MLWhistleMoanExport()); 
 		mlDataUnitsExport.add(new MLCPODExport()); 
 		mlDataUnitsExport.add(new MLRawExport()); 
+		mlDataUnitsExport.add(new MLNoiseExport());
 	}
 
 	@Override
@@ -197,7 +199,7 @@ public class MLDetectionsManager implements PamDataUnitExporter {
 			Struct mlStructure= Mat5.newStruct(new int[]{n, 1});
 
 			float sampleRate = -1;
-
+			PamDataBlock parentBlock = null;
 
 			n=0; 
 			//allocate the class now. 
@@ -208,6 +210,7 @@ public class MLDetectionsManager implements PamDataUnitExporter {
 					mlStructure=mlDataUnitsExport.get(i).detectionToStruct(mlStructure, dataUnits.get(j), n); 
 
 					sampleRate = dataUnits.get(j).getParentDataBlock().getSampleRate(); 
+					parentBlock = dataUnits.get(j).getParentDataBlock(); 
 					n++; 
 					alreadyStruct[j] = true;
 				}
@@ -216,6 +219,12 @@ public class MLDetectionsManager implements PamDataUnitExporter {
 			if (n>0) {
 				list.set(mlDataUnitsExport.get(i).getName(),mlStructure);
 				list.set(mlDataUnitsExport.get(i).getName()+"_sR", Mat5.newScalar(sampleRate)); 
+				
+				//set the header if there is one. 
+				if ( mlDataUnitsExport.get(i).detectionHeader(parentBlock)!=null) {
+					list.set(mlDataUnitsExport.get(i).getName()+"_metadata", mlDataUnitsExport.get(i).detectionHeader(parentBlock)); 
+				}
+
 			}
 		}
 

--- a/src/export/MLExport/MLNoiseExport.java
+++ b/src/export/MLExport/MLNoiseExport.java
@@ -1,0 +1,126 @@
+package export.MLExport;
+
+import org.jamdev.jdl4pam.utils.DLMatFile;
+
+import PamController.PamController;
+import PamController.soundMedium.GlobalMediumManager;
+import PamUtils.PamUtils;
+import PamguardMVC.PamDataBlock;
+import noiseMonitor.NoiseDataBlock;
+import noiseMonitor.NoiseDataUnit;
+import us.hebi.matlab.mat.format.Mat5;
+import us.hebi.matlab.mat.types.Matrix;
+import us.hebi.matlab.mat.types.Struct;
+import us.hebi.matlab.mat.types.Cell;
+
+
+
+/**
+ * Export a noise measurement to MATLAB 
+ * @author Jamie Macaulay
+ *
+ */
+public class MLNoiseExport extends MLDataUnitExport<NoiseDataUnit>{	
+
+
+	@Override
+	public Struct addDetectionSpecificFields(Struct mlStruct, int index, NoiseDataUnit noiseBandData) {
+
+		Matrix noiseBandDataM = DLMatFile.array2Matrix(noiseBandData.getNoiseBandData());
+
+		Matrix nBand = Mat5.newScalar(noiseBandData.getNoiseBandData().length); 
+		Matrix nMeasures = Mat5.newScalar(noiseBandData.getNoiseBandData()[0].length); 
+
+		mlStruct.set("nBand", index, nBand);
+		mlStruct.set("nMeasures",index, nMeasures);
+		mlStruct.set("noise", index, noiseBandDataM);
+
+		noiseBandData.getNoiseBandData(); 
+
+		return mlStruct;
+	}
+
+	@Override
+	public Class<?> getUnitClass() {
+		return NoiseDataUnit.class;
+	}
+
+	@Override
+	public String getName() {
+		return "noise_measurements";
+	}
+
+	@Override
+	protected Struct detectionHeader(PamDataBlock pamDataBlock) {
+		
+		try {
+			NoiseDataBlock noiseBandDataBlock = (NoiseDataBlock) pamDataBlock; 
+			
+			Struct struct = Mat5.newStruct(1, 1);
+			
+			Matrix hiEdges = DLMatFile.array2Matrix(noiseBandDataBlock.getBandHiEdges());
+			Matrix loEdges = DLMatFile.array2Matrix(noiseBandDataBlock.getBandLoEdges());
+			
+			struct.set("hiEdges", 0, hiEdges);
+			struct.set("loEdges",0, loEdges);
+			
+			// Get the name of the measures
+			String[] strings = getMeasureNames( noiseBandDataBlock);
+			
+			
+			
+			Cell cellArray = Mat5.newCell(1, strings.length);
+	
+			// Set each cell with a string
+			for (int i = 0; i < strings.length; i++) {
+				//System.out.println("Setting cell " + i + " to " + strings[i]);
+			    cellArray.set(i, Mat5.newString(strings[i]));
+			}
+			
+			struct.set("noise_descriptors", 0, cellArray);
+		
+			return struct;
+		}
+		
+		catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
+
+//		return null;
+	}
+	
+	
+	/**
+	 * Get the names of the noise measures
+	 * @param noiseBandDataBlock
+	 * @return a list of names
+	 */
+	public static String[] getMeasureNames(NoiseDataBlock noiseBandDataBlock) {
+		
+		//get integer bitmap of noise types
+		String[] strings = noiseBandDataBlock.getUsedMeasureNames();
+		
+		
+		//make more descriptive by adding units
+		for (int i=0; i<strings.length; i++) {
+			strings[i] = (strings[i] +  " (" + PamController.getInstance().getGlobalMediumManager().getdBRefString() + ")");
+		}
+		
+		
+//		int[] types  = PamUtils.getChannelArray(statisticTypes);
+//		
+//		String[] strings = new String[types.length]; 
+//
+//		for (int i=0; i<strings.length; i++) {
+//
+//			strings[i] = NoiseDataBlock.getMeasureName(types[i]);
+//			
+//			System.out.println("statisticTypes: " + statisticTypes+ " type: " 
+//			+ types[i] + "strings[i] : " + strings[i]);
+//
+//		}
+//		
+		return strings; 
+	}
+}

--- a/src/export/MLExport/MLRawExport.java
+++ b/src/export/MLExport/MLRawExport.java
@@ -3,12 +3,13 @@ package export.MLExport;
 import org.jamdev.jdl4pam.utils.DLMatFile;
 
 import PamUtils.PamUtils;
+import PamguardMVC.PamDataBlock;
 import PamguardMVC.PamDataUnit;
 import PamguardMVC.RawDataHolder;
-import pamMaths.PamVector;
 import us.hebi.matlab.mat.format.Mat5;
 import us.hebi.matlab.mat.types.Matrix;
 import us.hebi.matlab.mat.types.Struct;
+
 
 /**
  * Export data for any data unit which implements raw data holder. 
@@ -66,6 +67,11 @@ public class MLRawExport extends MLDataUnitExport<PamDataUnit<?,?>>{
 	@Override
 	public String getName() {
 		return "raw_data_units";
+	}
+
+	@Override
+	protected Struct detectionHeader(PamDataBlock pamDataBlock) {
+		return null;
 	}
 
 

--- a/src/export/MLExport/MLSuperDetExport.java
+++ b/src/export/MLExport/MLSuperDetExport.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.renjin.sexp.ListVector.NamedBuilder;
 
+import PamguardMVC.PamDataBlock;
 import PamguardMVC.PamDataUnit;
 import PamguardMVC.superdet.SuperDetection;
 import us.hebi.matlab.mat.format.Mat5;
@@ -113,6 +114,11 @@ public class MLSuperDetExport extends MLDataUnitExport {
 	@Override
 	public String getName() {
 		return "super_detection";
+	}
+
+	@Override
+	protected Struct detectionHeader(PamDataBlock pamDataBlock) {
+		return null;
 	}
 
 

--- a/src/export/MLExport/MLWhistleMoanExport.java
+++ b/src/export/MLExport/MLWhistleMoanExport.java
@@ -3,6 +3,7 @@ package export.MLExport;
 import org.jamdev.jdl4pam.utils.DLMatFile;
 
 import PamUtils.PamArrayUtils;
+import PamguardMVC.PamDataBlock;
 import us.hebi.matlab.mat.format.Mat5;
 import us.hebi.matlab.mat.types.Matrix;
 import us.hebi.matlab.mat.types.Struct;
@@ -120,6 +121,13 @@ public class MLWhistleMoanExport extends MLDataUnitExport<ConnectedRegionDataUni
 	@Override
 	public String getName() {
 		return "whistles";
+	}
+
+
+	@Override
+	protected Struct detectionHeader(PamDataBlock pamDataBlock) {
+		// TODO Auto-generated method stub
+		return null;
 	}
 
 }

--- a/src/export/RExport/RDataUnitExport.java
+++ b/src/export/RExport/RDataUnitExport.java
@@ -3,8 +3,10 @@ package export.RExport;
 import org.renjin.sexp.DoubleArrayVector;
 import org.renjin.sexp.IntArrayVector;
 import org.renjin.sexp.ListVector;
+import org.renjin.sexp.ListVector.NamedBuilder;
 import org.renjin.sexp.Vector;
 import PamUtils.PamCalendar;
+import PamguardMVC.PamDataBlock;
 import PamguardMVC.PamDataUnit;
 
 /**
@@ -131,6 +133,17 @@ public abstract class RDataUnitExport<T extends PamDataUnit<?, ?>> {
 		Vector newMatrix = DoubleArrayVector.newMatrix(concatWaveform, arr[0].length, arr.length); 
 		
 		return newMatrix;
+	}
+
+
+	/**
+	 * Get the header for a data unit. This is used to store information about the data unit
+	 * which is not specific to a detection. 
+	 * @param pamDataBlock - the data block
+	 * @return - a structure containing the header information. 
+	 */
+	protected NamedBuilder detectionHeader(PamDataBlock pamDataBlock) {
+		return null;
 	}
 
 

--- a/src/export/RExport/RExportManager.java
+++ b/src/export/RExport/RExportManager.java
@@ -17,6 +17,7 @@ import org.renjin.sexp.PairList;
 import org.renjin.sexp.PairList.Builder;
 
 import PamUtils.PamArrayUtils;
+import PamguardMVC.PamDataBlock;
 import PamguardMVC.PamDataUnit;
 import export.PamDataUnitExporter;
 import export.PamExporterManager;
@@ -52,7 +53,9 @@ public class RExportManager implements PamDataUnitExporter {
 		rDataExport.add(new RClickExport()); 
 		rDataExport.add(new RWhistleExport()); 
 		rDataExport.add(new RCPODExport()); 
+		rDataExport.add(new RNoiseExport()); //should be last in case raw data holders have specific exporters
 		rDataExport.add(new RRawExport()); //should be last in case raw data holders have specific exporters
+
 	}
 
 
@@ -189,6 +192,7 @@ public class RExportManager implements PamDataUnitExporter {
 
 			n=0; 
 			double sampleRate = 0.;
+			PamDataBlock parentBlock = null;
 			//allocate the class now. 
 			for (int j=0; j<dataUnits.size(); j++){
 				//check whether the same. 
@@ -201,6 +205,7 @@ public class RExportManager implements PamDataUnitExporter {
 					dataListArray.add(String.valueOf(dataUnits.get(j).getUID()), dataList);	
 
 					sampleRate = dataUnits.get(j).getParentDataBlock().getSampleRate(); 
+					parentBlock =  dataUnits.get(j).getParentDataBlock();
 					n++; 
 					alreadyStruct[j] = true;
 				}
@@ -216,6 +221,10 @@ public class RExportManager implements PamDataUnitExporter {
 
 				allData.add(dataName, dataListArray.build());
 				allData.add(rDataExport.get(i).getName()+"_sR",  new DoubleArrayVector(sampleRate));
+				
+				if (rDataExport.get(i).detectionHeader(parentBlock)!=null) {
+					allData.add(rDataExport.get(i).getName()+"_metadata", rDataExport.get(i).detectionHeader(parentBlock).build());
+				}
 
 				dataUnitTypes.add(rDataExport.get(i).getName()); 
 			}

--- a/src/export/RExport/RNoiseExport.java
+++ b/src/export/RExport/RNoiseExport.java
@@ -1,0 +1,79 @@
+package export.RExport;
+
+import org.jamdev.jdl4pam.utils.DLMatFile;
+import org.renjin.sexp.DoubleArrayVector;
+import org.renjin.sexp.ListVector;
+import org.renjin.sexp.Vector;
+import org.renjin.sexp.ListVector.NamedBuilder;
+import org.renjin.sexp.StringArrayVector;
+
+import PamguardMVC.PamDataBlock;
+import export.MLExport.MLNoiseExport;
+import noiseMonitor.NoiseDataBlock;
+import noiseMonitor.NoiseDataUnit;
+import us.hebi.matlab.mat.format.Mat5;
+import us.hebi.matlab.mat.types.Cell;
+import us.hebi.matlab.mat.types.Matrix;
+import us.hebi.matlab.mat.types.Struct;
+
+
+/**
+ * Export noise data to RData
+ * @author Jamie Macaulay
+ *
+ */
+public class RNoiseExport  extends RDataUnitExport<NoiseDataUnit> {
+
+	@Override
+	public NamedBuilder addDetectionSpecificFields(NamedBuilder rData, NoiseDataUnit noiseBandData, int index) {
+		
+		Vector newMatrix = doubleArr2R(noiseBandData.getNoiseBandData()); 
+		rData.add("noise", newMatrix); 
+	
+		rData.add("nMeasures", noiseBandData.getNoiseBandData()[0].length); 
+		rData.add("nBand",noiseBandData.getNoiseBandData().length); 
+
+		return rData;
+	}
+	
+	@Override
+	protected NamedBuilder detectionHeader(PamDataBlock pamDataBlock) {
+		ListVector.NamedBuilder rData = new ListVector.NamedBuilder();
+		
+		//now add some data specific to the noise data block.
+		
+		NoiseDataBlock noiseBandDataBlock = (NoiseDataBlock) pamDataBlock; 
+		
+		Struct struct = Mat5.newStruct(1, 1);
+		
+		Vector hiEdgesR =  new DoubleArrayVector(noiseBandDataBlock.getBandHiEdges()); 
+		Vector loEdgesR =  new DoubleArrayVector(noiseBandDataBlock.getBandLoEdges()); 
+
+		rData.add("hiEdges",hiEdgesR);
+		rData.add("loEdges",loEdgesR);
+		
+		// Get the name of the measures
+		String[] strings = MLNoiseExport.getMeasureNames( noiseBandDataBlock);
+		
+		// Create a StringArrayVector
+		StringArrayVector stringVector = new StringArrayVector(strings);
+
+		// Add to rData
+		rData.add("noise_descriptors", stringVector);
+		
+		return rData; 
+	}
+	
+	@Override
+	public Class<?> getUnitClass() {
+		return NoiseDataUnit.class;
+	}
+	
+
+	
+
+	@Override
+	public String getName() {
+		return "noise_band_data";
+	}
+}

--- a/src/noiseMonitor/NoiseDataBlock.java
+++ b/src/noiseMonitor/NoiseDataBlock.java
@@ -44,6 +44,8 @@ public class NoiseDataBlock extends PamDataBlock<NoiseDataUnit> implements Alarm
 	public static final String[] displayNames = {"Mean", "Median", "Lower 95%", "Upper 95%", "Minimum", "Maximim", "Peak"};
 	
 	private int statisticTypes;
+	
+	
 	private TethysNoiseDataProvider tethysNoiseDataProvider;
 	private FixedSpeciesManager fixedSpeciesManager;
 	

--- a/src/rawDeepLearningClassifier/layoutFX/DLSettingsPane.java
+++ b/src/rawDeepLearningClassifier/layoutFX/DLSettingsPane.java
@@ -339,13 +339,19 @@ public class DLSettingsPane  extends SettingsPane<RawDLParams>{
 		holder.setPadding(new Insets(5,5,5,5));
 		popOver.setContentNode(holder);
 
-
+		//set the parameters
 		popOver.showingProperty().addListener((obs, old, newval)->{
 			if (newval) {
+				//showing
 				dlControl.getDataSelector().getDialogPaneFX().setParams(true);
 			}
+			else {
+				//hiding
+				dlControl.getDataSelector().getDialogPaneFX().getParams(true);
+			}
 		});
-
+		
+	
 		popOver.show(dataSelectorButton);
 	} 
 


### PR DESCRIPTION
Added the ability to export noise data directly from PAMGuard. 

A sud spectrogram bug was caused because a reset was being called for the OfflineDataLoadInfo which cancelled the cancel order. This caused weird behaviour in the spectrgram displays on both time display and swing spectrgram with data arriving after it should have stopped loading. 

Fixed issue with canvas flags that meant whistles were not repainting when spectrogram was loading in time display

Fixed a bug where removing modules did not remove the module from list in time display

Fixed issue with the pop over data selector displays for clicks in raw deep learning display

Fixed issue with the prediction time plots. 