### PR TITLE
TerminalController: stop 100% CPU spin when stdin is closed"

### DIFF
--- a/src/PamController/command/TerminalController.java
+++ b/src/PamController/command/TerminalController.java
@@ -34,6 +34,7 @@ public class TerminalController extends CommandManager {
 
 	public void getTerminalCommands() {
 		Thread t = new Thread(new TerminalTread());
+		t.setDaemon(true); // don't stop the JVM from exiting at the end of batch processing
 		t.start();
 	}
 	
@@ -53,7 +54,14 @@ public class TerminalController extends CommandManager {
         try {
         	while (true) {
         		String command = reader.readLine();
-        		if (command != null && command.length() > 0) {
+        		if (command == null) {
+        			/*
+        			 * End of stream - stdin is closed (e.g. batch / container run with no
+        			 * terminal attached). Without this check the loop spins at 100% CPU.
+        			 */
+        			break;
+        		}
+        		if (command.length() > 0) {
         			interpretCommand(command);
         		}
 //        		System.out.println("you typed: " + inLine);
@@ -63,7 +71,7 @@ public class TerminalController extends CommandManager {
         	}
         } catch (IOException e) {
         	e.printStackTrace();
-        } 
+        }
         System.out.println("Exiting PAMGuard, leave control thread");
 	}
 }


### PR DESCRIPTION
Dear Doug and other contributors,
we're running PAMGuard containerized (Docker, headless -nogui batch mode) to process large volumes of sea-ambient-noise recordings on cloud infrastructure. It's working really well for us — along the way we hit a few small issues specific to headless/batch operation, and we'd like to contribute the fixes back. This is one of three related PRs.

## Problem

In headless operation (`-nogui`), `TerminalController.readCommands()` reads commands from stdin in a `while (true)` loop. When stdin is at end-of-stream — which is the normal situation in a Docker container, under a batch scheduler, or with `nohup`/redirected input — `BufferedReader.readLine()` returns `null` immediately and the loop never terminates, so the thread spins at 100% of one core for the entire run.

Thread dump from an affected containerised run (note cpu ≈ elapsed):

```
"Thread-2" ... cpu=106734.06ms elapsed=107.01s ... RUNNABLE
    at java.io.BufferedReader.readLine(BufferedReader.java:347)
    at PamController.command.TerminalController.readCommands(TerminalController.java:55)
```

Because the thread is also non-daemon, it prevents the JVM from ever exiting on its own if `System.exit` is not reached for any reason.

## Fix

- Break out of the read loop when `readLine()` returns `null` (EOF).
- Mark the terminal reader thread as a daemon so it cannot hold the JVM open after processing has finished.

Behaviour with a live interactive terminal is unchanged (`readLine()` blocks as before and commands are interpreted normally).

## Testing

Reproduced in a container running `-nogui -autostart -autoexit` batch processing: before the change one core is pinned at 100% for the whole run; after the change CPU use is normal and terminal commands still work when run interactively.

Thanks for taking a look and for maintaining PAMGuard.