### PR TITLE
Build wav file list synchronously in -nogui mode so -autostart cannot begin with an empty file list

### DIFF
--- a/src/Acquisition/FolderInputSystem.java
+++ b/src/Acquisition/FolderInputSystem.java
@@ -471,7 +471,7 @@ public class FolderInputSystem extends FileInputSystem implements PamSettings, D
 
 		if (folderInputPane==null) {
 
-			//need to make sure this is dynamically set - following means that the dialog will work 
+			//need to make sure this is dynamically set - following means that the dialog will work
 			//with whatever has been set by the user but if cancel is pressed settings will still revert.
 			boolean useSubFolders = false;
 			//			if (subFolders!=null) {
@@ -480,9 +480,21 @@ public class FolderInputSystem extends FileInputSystem implements PamSettings, D
 			//			else {
 			useSubFolders = folderInputParameters.subFolders;
 			//			}
-			//Swing way
-			wavListWorker.startFileListProcess(PamController.getMainFrame(), rootList,
-					useSubFolders, true);
+			if (PamGUIManager.getGUIType() == PamGUIManager.NOGUI) {
+				/*
+				 * Headless operation: catalogue the files synchronously so that allFiles
+				 * is complete before -autostart tries to prepare the acquisition. The
+				 * threaded version races the automatic start and loses on slow (e.g.
+				 * network mounted) file systems, aborting the run with
+				 * "No sound input files have been found".
+				 */
+				wavListWorker.startFileListProcessSync(rootList, useSubFolders, true);
+			}
+			else {
+				//Swing way
+				wavListWorker.startFileListProcess(PamController.getMainFrame(), rootList,
+						useSubFolders, true);
+			}
 		}
 		else {
 			//FX system

--- a/src/PamUtils/worker/filelist/FileListWorker.java
+++ b/src/PamUtils/worker/filelist/FileListWorker.java
@@ -88,7 +88,31 @@ public abstract class FileListWorker<T extends File> implements PamWorkWrapper<F
 	
 	
 	/**
-	 * Create a file list worker.  
+	 * Make a list from multiple files or root directories, running synchronously
+	 * on the calling thread. For nogui operation, where the file list must be
+	 * complete before automatic processing starts: the threaded version races
+	 * -autostart and can lose on slow (e.g. network mounted) file systems, leaving
+	 * the acquisition to start with an empty file list. No dialog is ever created.
+	 * @param rootList list of files or root directories to search
+	 * @param subFolders true to also search sub folders
+	 * @param useOldIfPossible use the previous list if the roots are unchanged
+	 */
+	public final void startFileListProcessSync(String[] rootList, boolean subFolders, boolean useOldIfPossible) {
+		this.fileList = rootList;
+		this.subFolders = subFolders;
+		this.useOldIfPossible = useOldIfPossible;
+		for (int i = 0; i < rootList.length; i++) {
+			Debug.out.println(">>>>>>>>Starting synchronous file search in " + rootList[i]);
+		}
+		if (noChange(rootList, subFolders, useOldIfPossible)) {
+			taskFinished(oldFileList);
+			return;
+		}
+		taskFinished(runBackgroundTask(null));
+	}
+
+	/**
+	 * Create a file list worker.
 	 * @param rootList - the list of folders to search in
 	 * @param subFolders - true to look for files in sub folders
 	 * @param useOldIfPossible
@@ -179,7 +203,9 @@ public abstract class FileListWorker<T extends File> implements PamWorkWrapper<F
 
 	private void addFiles(PamWorker<FileListData<T>> pamWorker, FileListData<T> newFileList, File folder) {
 		newFileList.addFolder();
-		pamWorker.update(new PamWorkProgressMessage(-1, "Searching folder " + folder.getAbsolutePath()));
+		if (pamWorker != null) {
+			pamWorker.update(new PamWorkProgressMessage(-1, "Searching folder " + folder.getAbsolutePath()));
+		}
 		Debug.out.println(">>>> Searching for files in abs path " + folder.getAbsolutePath());
 		//		System.out.println(folder.getAbsolutePath());
 		File[] moreFiles = folder.listFiles(fileFilter);
@@ -207,12 +233,17 @@ public abstract class FileListWorker<T extends File> implements PamWorkWrapper<F
 		
 		//Now all files in this folder have been added, so do any final tasks including checking for duplicates
 		String message = String.format("Found %d files - removing duplicates", newFileList.getFileCount());
-		pamWorker.update(new PamWorkProgressMessage(null, null, message));
+		if (pamWorker != null) {
+			pamWorker.update(new PamWorkProgressMessage(null, null, message));
+		}
 		newFileList.removeDuplicates("wav"); // remove duplicates and preferentially keep wav files
 	}
 
 	private void sayProgress(PamWorker<FileListData<T>> pamWorker, FileListData<T> newFileList, File folder) {
-		String msg = String.format("%d folders searched; %d sound files found in %d seconds...", 
+		if (pamWorker == null) {
+			return;
+		}
+		String msg = String.format("%d folders searched; %d sound files found in %d seconds...",
 				newFileList.getFoldersSearched(), newFileList.getFileCount(), (System.currentTimeMillis()-searchStartTime)/1000);
 		pamWorker.update(new PamWorkProgressMessage(null, null, msg));
 	}

--- a/src/PamUtils/worker/filelist/WavListWorker.java
+++ b/src/PamUtils/worker/filelist/WavListWorker.java
@@ -121,7 +121,9 @@ public class WavListWorker extends FileListWorker<WavFileType> {
 //					e.printStackTrace();
 					continue;
 				}
-				pamWorker.update(new PamWorkProgressMessage(ind*100/n, path));
+				if (pamWorker != null) {
+					pamWorker.update(new PamWorkProgressMessage(ind*100/n, path));
+				}
 			}
 			else {
 				fileList.addFile(aFile); // just put it back. 


### PR DESCRIPTION
Dear Douglas and Team,
this is PR2 of 3 and related to #317 and #319. All of them are related to the headless mode.
When starting my dockerized (headless) version and mounted a network attached hard drive, the file list was empty, because a race condition and this PR fixes it with a synchronous scan of files. I already tested it with my docker.

## Symptom

A headless batch run

```
java -jar Pamguard.jar PAMGuard -nogui -nosplash -noDialogs -autostart -autoexit \
     -psf config.psfx -wavfilefolder /data/audio -databasefile out.sqlite3 -binaryfolder bin
```

can abort at startup even though the wav folder contains valid files:

```
No sound input files have been found in location <folder stored in the psf>
FileInputSystem: runFileAnalysis: AudioFile format is null: Null File
Can't start since unable to prepare process Sound Acquisition
Adding file /data/audio/file1.wav          <- file list arrives AFTER the failed start
Adding file /data/audio/file2.wav
...
```

Note the `Adding file` lines (visible with `-debugout`) appearing *after* the acquisition failed to prepare: the file list was still being built when `-autostart` ran. After the failed start nothing retries, and since `-autoexit` only fires from `fileListComplete()`, the JVM then idles indefinitely.

Whether this bites depends purely on timing: on a fast local disk the listing usually wins the race and everything works; on slower storage (reproduced reliably with wav files on an S3 bucket mounted through a FUSE filesystem, where each file stat has network latency) the listing loses and the run aborts.

## Cause

`FolderInputSystem.makeSelFileList()` catalogues the wav folder asynchronously — `wavListWorker.startFileListProcess(...)` runs the scan in a `SwingWorker` and delivers the result later on the EDT via `taskFinished` → `newFileList()`, which populates `allFiles`. Nothing synchronises this against `-autostart`, whose `pamStart` → `prepareInputFile()` reads `allFiles`. If the scan has not finished, `allFiles` is empty and the start is aborted.

## Fix

In `-nogui` mode, catalogue the folder synchronously on the calling thread:

- `FileListWorker.startFileListProcessSync(...)` — same scan, same `taskFinished` delivery, but runs inline and never creates a dialog.
- `FolderInputSystem.makeSelFileList(String[])` calls it when `PamGUIManager.getGUIType() == PamGUIManager.NOGUI`.
- The progress-reporting calls in `FileListWorker`/`WavListWorker` are null-guarded since there is no `PamWorker` in the synchronous path.

`makeSelFileList` is invoked during settings load (module selection), so with the synchronous scan `allFiles` is always complete before `-autostart` can act, regardless of filesystem latency. Swing and FX GUI behaviour is unchanged.

## Testing

With the change, the same containerised batch run on slow storage catalogues all files first, processes them, and exits normally via `-autoexit`. Fast local runs are unaffected.

After this fix, I could access my S3 data via a fuse mount in the container.