### PR TITLE
Exit with an error code when an -autoexit batch run fails to start processing

### DIFF
--- a/src/PamController/PamController.java
+++ b/src/PamController/PamController.java
@@ -1349,6 +1349,15 @@ public class PamController implements PamControllerInterface, PamSettings {
 		}
 		boolean prepError = (runMode == PamController.RUN_NORMAL && prepErrors > 0);
 		if (prepError) {
+			if (GlobalArguments.getParam(AUTOEXIT) != null) {
+				/*
+				 * Batch run with no user present: if processing can't start, exit with an
+				 * error code rather than leaving the JVM idling forever (nothing else
+				 * would ever trigger the -autoexit System.exit).
+				 */
+				System.out.println("Unable to prepare processes for automatic processing. Exiting.");
+				System.exit(1);
+			}
 			return false;
 		}
 


### PR DESCRIPTION
Dear Doug,
this is the third PR, the others are #317 and #318. All three are related to the headless mode which is super nice. But they can also be seen or merged independently, but they belong functionally together, in my opinion.

Concerning this PR:
## Problem

In a headless batch run (`-nogui -autostart -autoexit`), if any process fails to prepare, `pamStart` prints

```
Can't start since unable to prepare process <name>
```

and returns `false` — and then nothing else ever happens. The only path to `System.exit` is `-autoexit` after successful completion, so the JVM sits idle forever. Under a batch scheduler (Docker, AWS Batch, HPC queues) the job looks like it is still running and burns its full allocation until the scheduler timeout kills it, and the failure is not distinguishable from a long run. (The container would never stop)

## Fix

When the `-autoexit` global argument is set and preparation fails, print a message and `System.exit(1)`, so schedulers see a failed job immediately. Exit code 1 is used to distinguish this from the normal `-autoexit` completion status. Interactive (GUI) behaviour is unchanged — the early return still simply leaves PAMGuard idle for the user.

Related to the startup race fixed in the synchronous file-list PR (#318): that race was one way to trigger this silent hang, but any preparation failure in a batch run has the same effect without this change.