### PR TITLE
Fix noise reduction: Threshold's raw-data passthrough runs regardless of settings

### DIFF
--- a/src/spectrogramNoiseReduction/SpectrogramNoiseProcess.java
+++ b/src/spectrogramNoiseReduction/SpectrogramNoiseProcess.java
@@ -139,8 +139,8 @@ public class SpectrogramNoiseProcess extends PamProcess {
 		}
 		
 		ThresholdParams p = (ThresholdParams) thresholdMethod.getParams();
-		if (p.finalOutput == SpectrogramThreshold.OUTPUT_RAW) {
-			thresholdMethod.pickEarlierData(fftData, newFFTUnit.getFftData());
+		if (noiseSettings.isRunMethod(methods.indexOf(thresholdMethod)) && p.finalOutput == SpectrogramThreshold.OUTPUT_RAW) {
+		    thresholdMethod.pickEarlierData(fftData, newFFTUnit.getFftData());
 		}
 		
 		// and output the data unit. 


### PR DESCRIPTION
SpectrogramNoiseProcess called thresholdMethod.pickEarlierData() gated only on ThresholdParams.finalOutput == OUTPUT_RAW, that method's own default value, never on whether Threshold is actually enabled via noiseSettings.isRunMethod(). This meant Threshold silently overwrote bins of every other enabled method's output (e.g. Average Subtraction) with unprocessed raw data on every slice, regardless of whether Threshold was ticked at all, with the overwrite condition depending only on the sign of each bin's (already-processed) real component. Confirmed via before/after spectrograms: corrupted, uniformly speckled noise-free output with the fix unapplied, clean whitened output with it applied.