### PR TITLE
Fix spectrogram control popup getting stuck open across file boundaries

### DIFF
--- a/src/PamView/hidingpanel/HidingDialog.java
+++ b/src/PamView/hidingpanel/HidingDialog.java
@@ -176,6 +176,31 @@ public class HidingDialog extends PamDialog {
 
 	}
 
+	/**
+	 * @return true if the pin button is currently engaged (dialog will not auto-hide
+	 * when the mouse moves away).
+	 */
+	public boolean isPinned() {
+		return pinButton.isSelected();
+	}
+
+	/**
+	 * Set the pinned state directly (as opposed to the user clicking the pin button),
+	 * keeping the icon and tooltip in sync. Used to restore pin state onto a freshly
+	 * rebuilt HidingDialog. Does not itself show/hide the dialog.
+	 */
+	public void setPinned(boolean pinned) {
+		pinButton.setSelected(pinned);
+		if (pinned) {
+			pinButton.setIcon(pinHide);
+			pinButton.setToolTipText("Hide dialog");
+		}
+		else {
+			pinButton.setIcon(pinImage);
+			pinButton.setToolTipText("Pin hiding dialog");
+		}
+	}
+
 	@Override
 	public boolean getParams() {
 		// TODO Auto-generated method stub

--- a/src/PamView/hidingpanel/HidingDialogPanel.java
+++ b/src/PamView/hidingpanel/HidingDialogPanel.java
@@ -290,7 +290,10 @@ public class HidingDialogPanel {
 		JRootPane rootPane = SwingUtilities.getRootPane(showButton);
 		Component root = SwingUtilities.getRoot(showButton);
 		if (rootPane != registeredRootPane || root != registeredRoot){
-			hidingDialog = null;
+			// The old hidingDialog (if any) is about to become unreachable. It's a genuine
+			// top level Window, so simply dropping the reference leaves it stuck on screen
+			// forever with nothing left to hide it. Close it properly first.
+			closeHidingDialog();
 			if (registeredRootPane != null) {
 				registeredRootPane.removeComponentListener(parentListener);
 				registeredRootPane.removeHierarchyListener(parentListener);
@@ -358,6 +361,41 @@ public class HidingDialogPanel {
 
 	public HidingDialog getHidingDialog() {
 		return hidingDialog;
+	}
+
+	/**
+	 * @return true if the popup dialog currently exists and is visible. Callers that
+	 * need to rebuild/replace this HidingDialogPanel can check this before calling
+	 * {@link #closeHidingDialog()}, in order to restore the open/closed state afterwards.
+	 */
+	public boolean isDialogVisible() {
+		return hidingDialog != null && hidingDialog.isVisible();
+	}
+
+	/**
+	 * @return true if the popup dialog currently exists and is pinned open. Callers that
+	 * need to rebuild/replace this HidingDialogPanel can check this before calling
+	 * {@link #closeHidingDialog()}, in order to restore the pinned state afterwards.
+	 */
+	public boolean isDialogPinned() {
+		return hidingDialog != null && hidingDialog.isPinned();
+	}
+
+	/**
+	 * Properly close and release the floating popup dialog, if one currently exists.
+	 * Must be called before this HidingDialogPanel (or its hidingDialog reference) is
+	 * discarded/replaced - e.g. when the owning display rebuilds its layout - otherwise
+	 * an open popup is orphaned: it's an independent top level Window, so dropping the
+	 * Java reference to it does NOT close it, it just leaves it stuck visible on screen
+	 * with no remaining code path (timer, listeners, pin button) able to hide it.
+	 */
+	public void closeHidingDialog() {
+		hidingTimer.stop();
+		if (hidingDialog != null) {
+			hidingDialog.setVisible(false);
+			hidingDialog.dispose();
+			hidingDialog = null;
+		}
 	}
 
 	private Component findRootPane(Component c) {

--- a/src/Spectrogram/SpectrogramDisplay.java
+++ b/src/Spectrogram/SpectrogramDisplay.java
@@ -58,6 +58,7 @@ import javax.swing.BoxLayout;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JLabel;
 import javax.swing.JLayeredPane;
+import javax.swing.SwingUtilities;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -1916,6 +1917,20 @@ InternalFrameListener, DisplayPanelContainer, SpectrogramParametersUser, PamSett
 			// need to remove the old plots first
 			removeAll();
 
+			// The old hidingDialogPanel (if any) is about to be replaced below. If its popup
+			// (freq/colour/map controls) happened to be open at this exact moment - which is
+			// common in file-based analysis, where this method gets re-triggered by model
+			// change events at file boundaries - just overwriting the field orphans the popup:
+			// it's a real top level Window, so losing the Java reference does not close it,
+			// it just gets stuck visible on screen with nothing left able to hide it. Close it
+			// properly first, but remember whether it was open (and pinned) so we can restore
+			// that state on the new HidingDialogPanel once it's built and on screen.
+			boolean reopenHidingDialog = hidingDialogPanel != null && hidingDialogPanel.isDialogVisible();
+			boolean reopenPinned = reopenHidingDialog && hidingDialogPanel.isDialogPinned();
+			if (hidingDialogPanel != null) {
+				hidingDialogPanel.closeHidingDialog();
+			}
+
 			//need to use layered panes
 			CornerLayoutContraint c = new CornerLayoutContraint();
 			spectroAndSidePanel = new SpecLayeredPane();
@@ -1930,6 +1945,24 @@ InternalFrameListener, DisplayPanelContainer, SpectrogramParametersUser, PamSett
 			hidingDialogPanel.setAutoHideTime(1000);
 			spectroAndSidePanel.add(hidingDialogPanel.getShowButton(), clc, JLayeredPane.PALETTE_LAYER);
 			c.anchor = CornerLayoutContraint.FILL;	
+
+			if (reopenHidingDialog) {
+				// showHidingDialog(true) positions itself relative to the show button, which
+				// isn't showing on screen yet at this point in layout - defer to the next
+				// EDT cycle, by which time this layout pass has completed and the button
+				// is realized, so the popup lands in the right place.
+				final HidingDialogPanel reopeningPanel = hidingDialogPanel;
+				final boolean pinned = reopenPinned;
+				SwingUtilities.invokeLater(new Runnable() {
+					@Override
+					public void run() {
+						reopeningPanel.showHidingDialog(true);
+						if (pinned) {
+							reopeningPanel.getHidingDialog().setPinned(true);
+						}
+					}
+				});
+			}
 
 			if (viewerScroller != null) {
 				add(BorderLayout.SOUTH, viewerScroller.getComponent());


### PR DESCRIPTION
## Bug
The floating spectrogram control popup (frequency range / colour limits / map, opened via the small tab on the spectrogram display) could get stuck open permanently, most commonly at file boundaries during file-based analysis, with no exception in the log.

## Root cause
`SpectrogramPlotPanel.layoutPlots()` in `SpectrogramDisplay.java` calls `removeAll()` and then unconditionally builds a **new** `HidingDialogPanel`, overwriting the field that held the old one. The popup itself (`HidingDialog`) is an independent, undecorated, non-modal `JDialog` - a real top-level window. Its only means of closing itself (mouse-position timer, pin button) lives inside the `HidingDialogPanel` object that just got discarded. If the popup happened to be open when `layoutPlots()` ran, it was orphaned: still visible on screen, with no remaining code path able to hide it.

`layoutPlots()` is re-triggered by `notifyModelChanged()` on `ADD_CONTROLLEDUNIT`/`REMOVE_CONTROLLEDUNIT`, which fire as the model reconfigures data blocks/sources between files during file-based analysis - matching the reported symptom.

A second copy of the same pattern existed in `HidingDialogPanel.showHidingDialog()`, in the branch that runs when the button's root window changes.

## Fix
- Added `HidingDialogPanel.closeHidingDialog()`, which properly stops the auto-hide timer and calls `setVisible(false)` + `dispose()` on the popup before it's discarded. Used in both leak locations.
- `layoutPlots()` now captures whether the popup was open (and pinned) immediately before closing it, then restores both states on the newly built `HidingDialogPanel` once the new show button is actually on screen (deferred via `SwingUtilities.invokeLater`, since `showHidingDialog()` positions itself relative to the button's on-screen location).
- Added `HidingDialog.isPinned()`/`setPinned()` and `HidingDialogPanel.isDialogVisible()`/`isDialogPinned()` accessors to support the above.

## Testing
Reproduced the original leak by opening the popup and forcing a `layoutPlots()` call (channel-count change / `setParams(..., true)`), confirmed a second, uncontrollable copy of the popup used to appear. After the fix, the popup closes cleanly and reopens (with pin state preserved) once the new layout is in place.